### PR TITLE
138675877 Add Account#memberships method

### DIFF
--- a/lib/pivotal-tracker/account.rb
+++ b/lib/pivotal-tracker/account.rb
@@ -24,7 +24,7 @@ class PivotalTracker::Account
         PivotalTracker::AccountMembership.new(membership)
       end
     else
-      puts "Only Admins and Owners can see account memberships"
+      raise(PivotalTracker::PermissionDenied, "Only Admins and Owners can see account memberships")
     end
   end
 end

--- a/lib/pivotal-tracker/account.rb
+++ b/lib/pivotal-tracker/account.rb
@@ -1,30 +1,32 @@
-class PivotalTracker::Account
-  attr_accessor :created_at, :days_left, :id, :kind,
-                :name, :over_the_limit, :plan, :project_ids,
-                :status, :updated_at
+class PivotalTracker
+  class Account
+    attr_accessor :created_at, :days_left, :id, :kind,
+                  :name, :over_the_limit, :plan, :project_ids,
+                  :status, :updated_at
 
-  def initialize(account_attributes)
-    account_attributes.each do |attribute, value|
-      self.send(:"#{attribute}=", value)
-    end
-  end
-
-  def self.find(account_id)
-    response = PivotalTracker.get("/accounts/#{account_id}")
-    if response.code == 200
-      parsed_response = response.parsed_response
-      PivotalTracker::Account.new(parsed_response)
-    end
-  end
-
-  def memberships
-    response = PivotalTracker.get("/accounts/#{self.id}/memberships")
-    if response.code == 200
-      response.parsed_response.map do |membership|
-        PivotalTracker::AccountMembership.new(membership)
+    def initialize(account_attributes)
+      account_attributes.each do |attribute, value|
+        self.send(:"#{attribute}=", value)
       end
-    else
-      puts response.inspect
+    end
+
+    def self.find(account_id)
+      response = PivotalTracker.get("/accounts/#{account_id}")
+      if response.code == 200
+        parsed_response = response.parsed_response
+        PivotalTracker::Account.new(parsed_response)
+      end
+    end
+
+    def memberships
+      response = PivotalTracker.get("/accounts/#{self.id}/memberships")
+      if response.code == 200
+        response.parsed_response.map do |membership|
+          PivotalTracker::AccountMembership.new(membership)
+        end
+      else
+        puts "Only Admins and Owners can see account memberships"
+      end
     end
   end
 end

--- a/lib/pivotal-tracker/account.rb
+++ b/lib/pivotal-tracker/account.rb
@@ -1,32 +1,30 @@
-class PivotalTracker
-  class Account
-    attr_accessor :created_at, :days_left, :id, :kind,
-                  :name, :over_the_limit, :plan, :project_ids,
-                  :status, :updated_at
+class PivotalTracker::Account
+  attr_accessor :created_at, :days_left, :id, :kind,
+                :name, :over_the_limit, :plan, :project_ids,
+                :status, :updated_at
 
-    def initialize(account_attributes)
-      account_attributes.each do |attribute, value|
-        self.send(:"#{attribute}=", value)
-      end
+  def initialize(account_attributes)
+    account_attributes.each do |attribute, value|
+      self.send(:"#{attribute}=", value)
     end
+  end
 
-    def self.find(account_id)
-      response = PivotalTracker.get("/accounts/#{account_id}")
-      if response.code == 200
-        parsed_response = response.parsed_response
-        PivotalTracker::Account.new(parsed_response)
-      end
+  def self.find(account_id)
+    response = PivotalTracker.get("/accounts/#{account_id}")
+    if response.code == 200
+      parsed_response = response.parsed_response
+      PivotalTracker::Account.new(parsed_response)
     end
+  end
 
-    def memberships
-      response = PivotalTracker.get("/accounts/#{self.id}/memberships")
-      if response.code == 200
-        response.parsed_response.map do |membership|
-          PivotalTracker::AccountMembership.new(membership)
-        end
-      else
-        puts "Only Admins and Owners can see account memberships"
+  def memberships
+    response = PivotalTracker.get("/accounts/#{self.id}/memberships")
+    if response.code == 200
+      response.parsed_response.map do |membership|
+        PivotalTracker::AccountMembership.new(membership)
       end
+    else
+      puts "Only Admins and Owners can see account memberships"
     end
   end
 end

--- a/lib/pivotal-tracker/account.rb
+++ b/lib/pivotal-tracker/account.rb
@@ -1,0 +1,30 @@
+class PivotalTracker::Account
+  attr_accessor :created_at, :days_left, :id, :kind,
+                :name, :over_the_limit, :plan, :project_ids,
+                :status, :updated_at
+
+  def initialize(account_attributes)
+    account_attributes.each do |attribute, value|
+      self.send(:"#{attribute}=", value)
+    end
+  end
+
+  def self.find(account_id)
+    response = PivotalTracker.get("/accounts/#{account_id}")
+    if response.code == 200
+      parsed_response = response.parsed_response
+      PivotalTracker::Account.new(parsed_response)
+    end
+  end
+
+  def memberships
+    response = PivotalTracker.get("/accounts/#{self.id}/memberships")
+    if response.code == 200
+      response.parsed_response.map do |membership|
+        PivotalTracker::AccountMembership.new(membership)
+      end
+    else
+      puts response.inspect
+    end
+  end
+end

--- a/lib/pivotal-tracker/account_membership.rb
+++ b/lib/pivotal-tracker/account_membership.rb
@@ -1,0 +1,4 @@
+class PivotalTracker::AccountMembership
+  def initialize(membership_attributes)
+  end
+end

--- a/lib/pivotal_tracker.rb
+++ b/lib/pivotal_tracker.rb
@@ -4,11 +4,11 @@ class PivotalTracker
 
 end
 
-require 'pivotal-tracker/client'
-require 'pivotal-tracker/story'
-require 'pivotal-tracker/project'
-require 'pivotal-tracker/account'
-require 'pivotal-tracker/account_membership'
+PivotalTracker.autoload :Client,            'pivotal-tracker/client'
+PivotalTracker.autoload :Story,             'pivotal-tracker/story'
+PivotalTracker.autoload :Project,           'pivotal-tracker/project'
+PivotalTracker.autoload :Account,           'pivotal-tracker/account'
+PivotalTracker.autoload :AccountMembership, 'pivotal-tracker/account_membership'
 
 class PivotalTracker
   include HTTParty

--- a/lib/pivotal_tracker.rb
+++ b/lib/pivotal_tracker.rb
@@ -7,6 +7,8 @@ end
 require 'pivotal-tracker/client'
 require 'pivotal-tracker/story'
 require 'pivotal-tracker/project'
+require 'pivotal-tracker/account'
+require 'pivotal-tracker/account_membership'
 
 class PivotalTracker
   include HTTParty

--- a/lib/pivotal_tracker.rb
+++ b/lib/pivotal_tracker.rb
@@ -14,4 +14,6 @@ class PivotalTracker
   include HTTParty
 
   base_uri 'https://www.pivotaltracker.com/services/v5'
+
+  PermissionDenied = Class.new(Error)
 end

--- a/spec/fixtures/pivotal_tracker_cassettes/account.yml
+++ b/spec/fixtures/pivotal_tracker_cassettes/account.yml
@@ -1,0 +1,243 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://www.pivotaltracker.com/services/v5/accounts//memberships
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Trackertoken:
+      - "<PIVOTAL_API_TOKEN>"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Access-Control-Allow-Headers:
+      - X-TrackerToken,DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,X-Tracker-Warn-Unless-Project-Version-Is
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 31 Jan 2017 00:59:55 GMT
+      Server:
+      - nginx + Phusion Passenger
+      Status:
+      - 404 Not Found
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Powered-By:
+      - Phusion Passenger Enterprise
+      X-Rack-Cache:
+      - miss
+      X-Request-Id:
+      - 5d32b0022035b72c16b087e5562eefd8
+      X-Runtime:
+      - '0.034957'
+      X-Tracker-Client-Pinger-Interval:
+      - '20'
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      X-Vcap-Request-Id:
+      - 5dc6e035-1bdd-4392-6cd2-83711681955f
+      Content-Length:
+      - '270'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"code":"unfound_resource","kind":"error","error":"The object you tried
+        to access could not be found.  It may have been removed by another user, you
+        may be using the ID of another object type, or you may be trying to access
+        a sub-resource at the wrong point in a tree."}'
+    http_version: 
+  recorded_at: Tue, 31 Jan 2017 00:59:55 GMT
+- request:
+    method: get
+    uri: https://www.pivotaltracker.com/services/v5/accounts/962753
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Trackertoken:
+      - "<PIVOTAL_API_TOKEN>"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Access-Control-Allow-Headers:
+      - X-TrackerToken,DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,X-Tracker-Warn-Unless-Project-Version-Is
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 31 Jan 2017 01:11:33 GMT
+      Etag:
+      - '"dffd11877efc45765449231dbb55d20e"'
+      Server:
+      - nginx + Phusion Passenger
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Powered-By:
+      - Phusion Passenger Enterprise
+      X-Rack-Cache:
+      - miss
+      X-Request-Id:
+      - f9ca7675f627a4a0699229bd3db2e681
+      X-Runtime:
+      - '0.096709'
+      X-Tracker-Client-Pinger-Interval:
+      - '20'
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      X-Vcap-Request-Id:
+      - 87f596cc-ba42-4fc8-5769-73d5ed162286
+      Content-Length:
+      - '187'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"kind":"account","id":962753,"name":"GEM RSPEC ACCOUNT MEMBERSHIP","plan":"Free","status":"active","days_left":30,"created_at":"2017-01-31T00:37:00Z","updated_at":"2017-01-31T00:37:00Z"}'
+    http_version: 
+  recorded_at: Tue, 31 Jan 2017 01:11:33 GMT
+- request:
+    method: get
+    uri: https://www.pivotaltracker.com/services/v5/accounts/962753/memberships
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Trackertoken:
+      - "<PIVOTAL_API_TOKEN>"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Access-Control-Allow-Headers:
+      - X-TrackerToken,DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,X-Tracker-Warn-Unless-Project-Version-Is
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 31 Jan 2017 01:18:09 GMT
+      Etag:
+      - '"514f260f6f20b70641badcb59f29593c"'
+      Server:
+      - nginx + Phusion Passenger
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Powered-By:
+      - Phusion Passenger Enterprise
+      X-Rack-Cache:
+      - miss
+      X-Request-Id:
+      - 4a29b48b95ec0ce52d8065db3596aadc
+      X-Runtime:
+      - '0.060767'
+      X-Tracker-Client-Pinger-Interval:
+      - '20'
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      X-Vcap-Request-Id:
+      - 1f165f9f-00bf-4a3a-62f7-009bafcac804
+      Content-Length:
+      - '736'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '[{"kind":"account_membership","id":2413445,"person":{"kind":"person","id":2413445,"name":"Kyle
+        Heppenstall","email":"kyle.heppenstall@gmail.com","initials":"KH","username":"kyleheppenstall"},"account_id":962753,"created_at":"2017-01-31T00:56:25Z","updated_at":"2017-01-31T00:56:25Z","owner":false,"admin":false,"project_creator":false,"timekeeper":false,"time_enterer":false},{"kind":"account_membership","id":2415615,"person":{"kind":"person","id":2415615,"name":"Mike
+        Schutte","email":"<PIVOTAL_EMAIL_ADDRESS>","initials":"TMS","username":"<PIVOTAL_USER_NAME>"},"account_id":962753,"created_at":"2017-01-31T00:37:00Z","updated_at":"2017-01-31T00:37:00Z","owner":true,"admin":false,"project_creator":false,"timekeeper":true,"time_enterer":false}]'
+    http_version: 
+  recorded_at: Tue, 31 Jan 2017 01:18:09 GMT
+- request:
+    method: get
+    uri: https://www.pivotaltracker.com/services/v5/accounts/123456789123456789
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Trackertoken:
+      - "<PIVOTAL_API_TOKEN>"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Access-Control-Allow-Headers:
+      - X-TrackerToken,DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,X-Tracker-Warn-Unless-Project-Version-Is
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 31 Jan 2017 01:39:23 GMT
+      Server:
+      - nginx + Phusion Passenger
+      Status:
+      - 404 Not Found
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Powered-By:
+      - Phusion Passenger Enterprise
+      X-Rack-Cache:
+      - miss
+      X-Request-Id:
+      - 5b176c5a9e6a799c816c78aab5782f07
+      X-Runtime:
+      - '0.032347'
+      X-Tracker-Client-Pinger-Interval:
+      - '20'
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      X-Vcap-Request-Id:
+      - f956dac4-c61f-4dd8-55cb-dabf559ba27a
+      Content-Length:
+      - '270'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"code":"unfound_resource","kind":"error","error":"The object you tried
+        to access could not be found.  It may have been removed by another user, you
+        may be using the ID of another object type, or you may be trying to access
+        a sub-resource at the wrong point in a tree."}'
+    http_version: 
+  recorded_at: Tue, 31 Jan 2017 01:39:23 GMT
+recorded_with: VCR 3.0.3

--- a/spec/lib/pivotal-tracker/account_spec.rb
+++ b/spec/lib/pivotal-tracker/account_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+describe PivotalTracker::Account do
+  # We will be testing the class, not the instance
+  subject { PivotalTracker::Account }
+
+  before do
+    set_token
+    VCR.insert_cassette 'account', :record => :new_episodes
+  end
+
+  after do
+    VCR.eject_cassette
+  end
+
+  describe "#find" do
+    let(:account) { subject.find(account_id) }
+    context "with a valid account id" do
+      let(:account_id) { 962753 }
+
+      it "is an account" do
+        expect(account).to be_a(PivotalTracker::Account)
+      end
+
+      it "has the right id" do
+        expect(account.id).to eq(account_id)
+      end
+    end
+
+    context "with an invalid account id" do
+      let(:account_id) { 123456789123456789 }
+
+      it "returns nil" do
+        expect(account).to be_nil
+      end
+    end
+  end
+
+  describe '.memberships' do
+    let(:account) { subject.find(962753) }
+
+    it "returns all memberships" do
+      expect(account.memberships).to be_an(Array)
+    end
+
+    it "all returned objects are memberships" do
+      account.memberships.each do |membership|
+        expect(membership).to be_a(PivotalTracker::AccountMembership)
+      end
+    end
+  end
+end

--- a/spec/lib/pivotal-tracker/account_spec.rb
+++ b/spec/lib/pivotal-tracker/account_spec.rb
@@ -16,7 +16,7 @@ describe PivotalTracker::Account do
   describe "#find" do
     let(:account) { subject.find(account_id) }
     context "with a valid account id" do
-      let(:account_id) { 962753 }
+      let(:account_id) { ENV['PIVOTAL_ACCOUNT_ID'].to_i }
 
       it "is an account" do
         expect(account).to be_a(PivotalTracker::Account)
@@ -37,7 +37,7 @@ describe PivotalTracker::Account do
   end
 
   describe '.memberships' do
-    let(:account) { subject.find(962753) }
+    let(:account) { subject.find(ENV['PIVOTAL_ACCOUNT_ID'].to_i) }
 
     it "returns all memberships" do
       expect(account.memberships).to be_an(Array)


### PR DESCRIPTION
Worked with @kheppenstall and @damwhit

Add Account.find(account_id) and Account#memberships methods for related
API endpoints. All tests pass.

In order to get an account ID, we had to make a test account (which I own). We can plan on using this for the `/accounts/:id` endpoints.

[#138675877]