### PR TITLE
[WIP] 138673925 special characters allowed in password for API calls

### DIFF
--- a/spec/lib/pivotal-tracker/special_character_password_spec.rb
+++ b/spec/lib/pivotal-tracker/special_character_password_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+
+describe PivotalTracker do
+  context "account with special characters in password" do
+    describe "GET me" do
+      before do
+        PivotalTracker::Client.token = ENV['PIVOTAL_TOKEN_ID']
+        VCR.insert_cassette 'profile', :record => :new_episodes
+      end
+
+      after do
+        VCR.eject_cassette
+      end
+
+      it "records the fixture" do
+        PivotalTracker.get('/me')
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,7 +32,7 @@ VCR.configure do |c|
     ENV['PIVOTAL_USER_NAME']
   end
   c.filter_sensitive_data('<PIVOTAL_PASSWORD>') do |interaction|
-    ENV['PIVOTAL_USER_PASSWORD']
+    CGI.escape(ENV['PIVOTAL_USER_PASSWORD'])
   end
 end
 


### PR DESCRIPTION
Edit the PIVOTAL_USER_PASSWORD in spec_helper.rb to use CGI.escape so that special characters are sanitized when passed in an API call to make the VCR.

[#138673925]

I ended up making a test file but all it does is copy in a test from a different file. Since tests were already failing it could make sense to not include the extra `special_character_password_spec.rb` file.

As of now the tests are only truly testing this functionality if you password contains special characters. Thoughts on how we might 'lock in' a password with special characters somehow into a VCR to test this properly regardless of your individual password?