### PR TITLE
 138673925 password allow special characters v5

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,7 +32,7 @@ VCR.configure do |c|
     ENV['PIVOTAL_USER_NAME']
   end
   c.filter_sensitive_data('<PIVOTAL_PASSWORD>') do |interaction|
-    ENV['PIVOTAL_USER_PASSWORD']
+    CGI.escape(ENV['PIVOTAL_USER_PASSWORD'])
   end
   c.filter_sensitive_data('<PROJECT_ID>') do |interaction|
     ENV['PROJECT_ID']


### PR DESCRIPTION
Remove bug when a developer clones the repo, fills in information in .env file, and has special characters in his/her Pivotal Tracker Password. The CGI.escape(password) makes the password valid in a URI.

[#138673925]