### PR TITLE
138828517 add project workspace resource

### DIFF
--- a/lib/pivotal-tracker/project_workspace.rb
+++ b/lib/pivotal-tracker/project_workspace.rb
@@ -1,5 +1,5 @@
 require './lib/pivotal-tracker/resource'
 
 class PivotalTracker::ProjectWorkspace < PivotalTracker::Resource
-  attr_accessor :id, :position_int, :project_id, :workspace_id, :kind
+  attr_accessor :id, :kind, :position_int, :project_id, :workspace_id
 end

--- a/lib/pivotal-tracker/project_workspace.rb
+++ b/lib/pivotal-tracker/project_workspace.rb
@@ -1,0 +1,5 @@
+require './lib/pivotal-tracker/resource'
+
+class PivotalTracker::ProjectWorkspace < PivotalTracker::Resource
+  attr_accessor :id, :position_int, :project_id, :workspace_id, :kind
+end

--- a/lib/pivotal-tracker/resource.rb
+++ b/lib/pivotal-tracker/resource.rb
@@ -1,0 +1,7 @@
+class PivotalTracker::Resource
+  def initialize(attributes)
+    attributes.each do |attribute, value|
+      self.send(:"#{attribute}=", value)
+    end
+  end
+end

--- a/lib/pivotal_tracker.rb
+++ b/lib/pivotal_tracker.rb
@@ -9,6 +9,8 @@ PivotalTracker.autoload :Story,             'pivotal-tracker/story'
 PivotalTracker.autoload :Project,           'pivotal-tracker/project'
 PivotalTracker.autoload :Account,           'pivotal-tracker/account'
 PivotalTracker.autoload :AccountMembership, 'pivotal-tracker/account_membership'
+PivotalTracker.autoload :ProjectWorkspace,  'pivotal-tracker/project_workspace'
+PivotalTracker.autoload :Resource,          'pivotal-tracker/resource'
 
 class PivotalTracker
   include HTTParty

--- a/spec/lib/pivotal-tracker/project_workspace_spec.rb
+++ b/spec/lib/pivotal-tracker/project_workspace_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe PivotalTracker::ProjectWorkspace do
+  
+  describe '#new' do
+    it 'initializes with attributes' do
+      attributes = {id: 1, position_int: 1, project_id: 1, workspace_id: 1, kind: 'kind'}
+      project_workspace =  PivotalTracker::ProjectWorkspace.new(attributes)
+
+      expect(project_workspace).to be_a PivotalTracker::ProjectWorkspace
+
+      attributes.each do |attribute, value|
+        expect(project_workspace.send(attribute)).to eq(value)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Unit test for initializing a project workspace and reading its attributes. Extract initialize method into a base class `PivotalTracker::Resource`.

[#138828517]