### PR TITLE
Add google attachment resource with model test

### DIFF
--- a/lib/pivotal-tracker/google_attachment.rb
+++ b/lib/pivotal-tracker/google_attachment.rb
@@ -1,0 +1,5 @@
+class PivotalTracker::GoogleAttachment < PivotalTracker::Resource
+  attr_accessor :alternate_link, :comment_id, :google_id,
+                :google_kind, :id, :kind, :person_id,
+                :resource_id, :title
+end

--- a/lib/pivotal_tracker.rb
+++ b/lib/pivotal_tracker.rb
@@ -1,4 +1,5 @@
 require 'httparty'
+require 'pry'
 
 class PivotalTracker
 
@@ -11,9 +12,10 @@ PivotalTracker.autoload :Account,           'pivotal-tracker/account'
 PivotalTracker.autoload :AccountMembership, 'pivotal-tracker/account_membership'
 PivotalTracker.autoload :ProjectWorkspace,  'pivotal-tracker/project_workspace'
 PivotalTracker.autoload :Resource,          'pivotal-tracker/resource'
-PivotalTracker.autoload :JiraIntegration, 'pivotal-tracker/jira_integration'
+PivotalTracker.autoload :JiraIntegration,   'pivotal-tracker/jira_integration'
 PivotalTracker.autoload :Me,                'pivotal-tracker/me'
 PivotalTracker.autoload :MembershipSummary, 'pivotal-tracker/membership_summary'
+PivotalTracker.autoload :GoogleAttachment,  'pivotal-tracker/google_attachment'
 
 class PivotalTracker
   include HTTParty

--- a/lib/pivotal_tracker.rb
+++ b/lib/pivotal_tracker.rb
@@ -1,8 +1,11 @@
 require 'httparty'
-require 'pry'
 
 class PivotalTracker
+  include HTTParty
 
+  base_uri 'https://www.pivotaltracker.com/services/v5'
+
+  PermissionDenied = Class.new(Error)
 end
 
 PivotalTracker.autoload :Client,            'pivotal-tracker/client'
@@ -16,11 +19,3 @@ PivotalTracker.autoload :JiraIntegration,   'pivotal-tracker/jira_integration'
 PivotalTracker.autoload :Me,                'pivotal-tracker/me'
 PivotalTracker.autoload :MembershipSummary, 'pivotal-tracker/membership_summary'
 PivotalTracker.autoload :GoogleAttachment,  'pivotal-tracker/google_attachment'
-
-class PivotalTracker
-  include HTTParty
-
-  base_uri 'https://www.pivotaltracker.com/services/v5'
-
-  PermissionDenied = Class.new(Error)
-end

--- a/spec/lib/pivotal-tracker/google_attachment_spec.rb
+++ b/spec/lib/pivotal-tracker/google_attachment_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe PivotalTracker::GoogleAttachment do
+  # We will be testing the class, not the instance
+  subject { PivotalTracker::GoogleAttachment }
+
+  describe ".new" do
+    it "can initialize an instance with attributes" do
+      attributes = {
+        id: 123, comment_id: 987, person_id: 654,
+        google_kind: 'string', title: 'string',
+        google_id: 'string', alternate_link: 'string',
+        resource_id: 'string', kind: 'string'
+      }
+
+      google_attachment = subject.new(attributes)
+      expect(google_attachment).to be_a PivotalTracker::GoogleAttachment
+
+      attributes.each do |attribute, value|
+        expect(google_attachment.send(attribute)).to eq(value)
+      end
+    end
+  end
+end


### PR DESCRIPTION
I looked into a more consolidated way to autoload the sub resources in PivotalTracker, but couldn't find a simple solution.

[#138672709]